### PR TITLE
Fixe : Reaction error while changing 

### DIFF
--- a/dist/discord_embed_menu.js
+++ b/dist/discord_embed_menu.js
@@ -174,6 +174,9 @@ class DiscordEmbedMenu extends events_1.EventEmitter {
                 }
                 if (reactionName && this.menu) {
                     if (typeof this.currentPage.reactions[reactionName] === 'function') {
+                        // this this flag is not true then the clearReaction() at ligne 188 will be never call when try to change page
+                        // also test when no page change it works too
+                        reactionsChanged = true;
                         return this.currentPage.reactions[reactionName](this);
                     }
                     switch (this.currentPage.reactions[reactionName]) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "discord.js-embed-menu",
   "description": "Easily create Discord.js embed menus with reactions and unlimited customisable pages.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "eilex",
   "license": "MIT",
   "main": "dist/main.js",

--- a/src/discord_embed_menu.ts
+++ b/src/discord_embed_menu.ts
@@ -207,6 +207,9 @@ export class DiscordEmbedMenu extends EventEmitter {
     
                 if (reactionName && this.menu) {
                     if (typeof this.currentPage.reactions[reactionName] === 'function') {
+                        // this this flag is not true then the clearReaction() at ligne 188 will be never call when try to change page
+                        // also test when no page change it works too
+                        reactionsChanged=true;
                         return this.currentPage.reactions[reactionName](this);
                     }
     


### PR DESCRIPTION
This PR fix the #1 bug that add reaction while try to use `setPage()` with reaction function callback.
This happened because the `reactionsChanged` var was `undefined` on collector `end` event, so the `clearReactions()` method wasn't called.

To solve that, I simply defined `reactionsChanged` as true before call the emoji's function.